### PR TITLE
Minor fix to io module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.0.8] - 2019-12-22
+- Minor fix to io module, which is copied to the new workspace after `les --init`
+
 ## [1.0.7] - 2019-12-18
 - Moved some generic utilities to les-utils project. Easier to reuse.
 - Updated the les-utils version in package.json.

--- a/io.js
+++ b/io.js
@@ -32,8 +32,11 @@ function IOServer({ host, port, server = http.createServer() }) {
   }
 
   function listen() {
-    return new Promise((resolve) => {
-      server.listen(port, host, resolve)
+    return new Promise((resolve, reject) => {
+      server
+        .listen(port, host)
+        .on('error', reject)
+        .on('listening', resolve)
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lesky",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Lightweight Express-ish (Koa) Server - Type les not More!",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
- The io module is copied over to the new workspace that `les --init` initializes.  The listen method just needed to resolve properly.